### PR TITLE
Added support for PHP < 8

### DIFF
--- a/src/Dashboards/APCu/APCuTrait.php
+++ b/src/Dashboards/APCu/APCuTrait.php
@@ -176,7 +176,7 @@ trait APCuTrait {
         foreach ($info['cache_list'] as $key_data) {
             $key = $key_data['info'];
 
-            if (stripos($key, $search) !== false) {
+            if (empty($search) || stripos($key, $search) !== false) {
                 $keys[] = [
                     'key'    => $key,
                     'base64' => true,

--- a/src/Dashboards/Memcached/MemcachedTrait.php
+++ b/src/Dashboards/Memcached/MemcachedTrait.php
@@ -194,7 +194,7 @@ trait MemcachedTrait {
         foreach ($this->memcached->getKeys() as $key_data) {
             $key = $key_data['key'] ?? $key_data;
 
-            if (stripos($key, $search) !== false) {
+            if (empty($search) || stripos($key, $search) !== false) {
                 $ttl = $key_data['exp'] ?? null;
 
                 $keys[] = [

--- a/src/Dashboards/OPCache/OPCacheTrait.php
+++ b/src/Dashboards/OPCache/OPCacheTrait.php
@@ -101,7 +101,7 @@ trait OPCacheTrait {
                     continue;
                 }
 
-                if (stripos($script['full_path'], $search) !== false) {
+                if (empty($search) || stripos($script['full_path'], $search) !== false) {
                     $cached_scripts[] = [
                         'key'   => $script['full_path'],
                         'items' => [


### PR DESCRIPTION
As described in https://github.com/RobiNN1/phpCacheAdmin/issues/21 the current implementation doesn't work well with PHP7. This PR adds some backwards-compatability.