### PR TITLE
Fix FOUC on refresh/page load

### DIFF
--- a/assets/js/scripts.js
+++ b/assets/js/scripts.js
@@ -377,9 +377,6 @@ const init_theme_switcher = () => {
     });
 };
 
-update_theme();
-init_theme_switcher();
-
 /**
  * Modal
  */
@@ -424,4 +421,6 @@ class Modal {
 
 document.addEventListener('DOMContentLoaded', () => {
     document.querySelectorAll('.modal').forEach(modal => new Modal(modal));
+    update_theme();
+    init_theme_switcher();
 });

--- a/assets/js/theme.js
+++ b/assets/js/theme.js
@@ -1,0 +1,5 @@
+document.documentElement.classList.toggle(
+    "dark",
+    localStorage.theme === "dark" ||
+    (!("theme" in localStorage) && window.matchMedia("(prefers-color-scheme: dark)").matches),
+);

--- a/templates/layout.twig
+++ b/templates/layout.twig
@@ -16,6 +16,7 @@
         </style>
     {%- endif %}
 
+    <script src="assets/js/theme.js?v={{ version }}"></script>
 </head>
 <body class="bg-gray-100 text-gray-900 dark:text-gray-200 dark:bg-gray-900" data-dashboard="{{ current }}">
 <header class="grid md:grid-cols-3 p-4 bg-white dark:bg-gray-800 border-b border-gray-200 dark:border-gray-700">


### PR DESCRIPTION
A flash of white (FOUC) appears on page refresh because the theme is set in a script that loads after the page finishes rendering.
This pull request improves theme management by moving the initialization to a separate script, ensuring it runs earlier during page load
If you prefer not to create a separate JavaScript file for the theme, you can place the code directly inside a ``<script>`` tag. Let me know if you have a better approach!